### PR TITLE
fix: pin reth version, fix: backfill example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1752d7d62e2665da650a36d84abbf239f812534475d51f072a49a533513b7cdd"
+checksum = "3312b2a48f29abe7c3ea7c7fbc1f8cc6ea09b85d74b6232e940df35f2f3826fd"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -137,14 +137,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58047cc851e58c26224521d1ecda466e3d746ebca0274cd5427aa660a88c353"
+checksum = "04c309895995eaa4bfcc345f5515a39c7df9447798645cc8bf462b6c5bf1dc96"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "arbitrary",
  "c-kzg",
  "serde",
@@ -165,7 +165,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.13",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -185,30 +185,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
+checksum = "d9431c99a3b3fe606ede4b3d4043bdfbcb780c45b8d8d226c3804e2b75cfbe68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "arbitrary",
  "c-kzg",
  "derive_more",
  "k256",
  "once_cell",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cb76c8a3913f2466c5488f3a915e3a15d15596bdc935558c1a9be75e9ec508"
+checksum = "79614dfe86144328da11098edcc7bc1a3f25ad8d3134a9eb9e857e06f0d9840d"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "serde",
 ]
 
@@ -226,11 +227,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
+checksum = "57e2865c4c3bb4cdad3f0d9ec1ab5c0c657ba69a375651bd35e32fb6c180ccc2"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -239,22 +241,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
+checksum = "6e701fc87ef9a3139154b0b4ccb935b565d27ffd9de020fe541bf2dec5ae4ede"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.2.0",
- "alloy-serde 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
+ "alloy-serde 0.2.1",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
  "thiserror",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d5a0f9170b10988b6774498a022845e13eda94318440d17709d50687f67f9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.2.1",
+ "serde",
 ]
 
 [[package]]
@@ -286,26 +300,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
+checksum = "3f9c0ab10b93de601a6396fc7ff2ea10d3b28c46f079338fa562107ebf9857c8"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "futures-utils-wasm",
  "lru",
@@ -320,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64acfec654ade392cecfa9bba0408eb2a337d55f1b857925da79970cb70f3d6"
+checksum = "3f5da2c55cbaf229bad3c5f8b00b5ab66c74ef093e5f3a753d874cfecf7d2281"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -339,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -350,20 +365,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83524c1f6162fcb5b0decf775498a125066c86dda6066ed609531b0e912f85a"
+checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
+checksum = "5b38e3ffdb285df5d9f60cb988d336d9b8e3505acb78750c3bc60336a7af41d3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -385,22 +400,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5d76f1e8b22f48b7b8f985782b68e7eb3938780e50e8b646a53e41a598cdf5"
+checksum = "e6c31a3750b8f5a350d17354e46a52b0f2f19ec5f2006d816935af599dedc521"
 dependencies = [
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
  "alloy-rpc-types-trace",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137f0014c3a61ccc5168289fcc214d7296c389c0bf60425c0f898cff1d7e4bec"
+checksum = "fbfb8b2c2eea8acd5580c9804a1ee58038938b16efb24eec09c3005f65b0e4ad"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -410,22 +425,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4282c002a4ae9f57887dae57083fcca6dca09cb6685bf98b8582ea93cb3df97d"
+checksum = "52ab6509cd38b2e8c8da726e0f61c1e314a81df06a38d37ddec8bced3f8d25ed"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b47dcc8e3bebea57b1c9495a7e6f3313e99d355c0f5b80473cfbdfcbdd6ebea"
+checksum = "c8a24bcff4f9691d7a4971b43e5da46aa7b4ce22ed7789796612dc1eed220983"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "serde",
@@ -435,16 +450,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73445fbc5c02258e3d0d977835c92366a4d91545fd456c3fc8601c61810bc9f6"
+checksum = "ff63f51b2fb2f547df5218527fd0653afb1947bf7fead5b3ce58c75d170b30f7"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 0.2.0",
- "alloy-serde 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
+ "alloy-serde 0.2.1",
  "jsonrpsee-types",
  "jsonwebtoken",
  "rand 0.8.5",
@@ -472,15 +487,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605fa8462732bb8fd0645a9941e12961e079d45ae6a44634c826f8229c187bdf"
+checksum = "81e18424d962d7700a882fe423714bd5b9dde74c7a7589d4255ea64068773aef"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "alloy-sol-types",
  "itertools 0.13.0",
  "jsonrpsee-types",
@@ -491,26 +507,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffcb83a5a91d327c40ba2157a19016bb883c1426f1708fea5f9e042032fd73e"
+checksum = "5a0593a17b4b009598eb3e8380e298c53bd5581f3f37d85a38e6a34881c90ea1"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f561a8cdd377b6ac3beab805b9df5ec2c7d99bb6139aab23c317f26df6fb346"
+checksum = "a86eeb49ea0cc79f249faa1d35c20541bb1c317a59b5962cb07b1890355b0064"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.2.0",
- "alloy-serde 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
+ "alloy-serde 0.2.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -518,13 +534,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06a4bd39910631c11148c5b2c55e2c61f8626affd2a612e382c668d5e5971ce"
+checksum = "c2342fed8175642b15a37a51f8729b05b2469281fbeb816f0ccbb0087e2dd74a"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.2.0",
- "alloy-serde 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
+ "alloy-serde 0.2.1",
  "serde",
 ]
 
@@ -541,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
+checksum = "e33feda6a53e6079895aed1d08dcb98a1377b000d80d16370fbbdb8155d547ef"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -553,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
+checksum = "740a25b92e849ed7b0fa013951fe2f64be9af1ad5abe805037b44fb7770c5c47"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -576,7 +592,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -589,11 +605,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -611,7 +627,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.71",
+ "syn 2.0.72",
  "syn-solidity",
 ]
 
@@ -622,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
 dependencies = [
  "serde",
- "winnow 0.6.13",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -640,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
+checksum = "3d0590afbdacf2f8cca49d025a2466f3b6584a016a8b28f532f29f8da1007bae"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -659,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
+checksum = "2437d145d80ea1aecde8574d2058cceb8b3c9cba05f6aea8e67907c660d46698"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -674,14 +690,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ccc1c8f8ae415e93ec0e7851bd4cdf4afdd48793d13a91b860317da1f36104"
+checksum = "af855163e7df008799941aa6dd324a43ef2bf264b08ba4b22d44aad6ced65300"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.1.0",
+ "http",
  "rustls",
  "serde_json",
  "tokio",
@@ -698,9 +714,13 @@ checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
+ "derive_arbitrary",
  "derive_more",
  "hashbrown 0.14.5",
  "nybbles",
+ "proptest",
+ "proptest-derive 0.4.0",
  "serde",
  "smallvec",
  "tracing",
@@ -723,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -738,33 +758,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -787,7 +807,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -925,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -943,9 +963,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
 dependencies = [
  "brotli",
  "flate2",
@@ -976,7 +996,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -987,7 +1007,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1025,7 +1045,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1044,7 +1064,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "itoa",
@@ -1070,7 +1090,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -1165,15 +1185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,7 +1216,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1309,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
@@ -1328,7 +1339,7 @@ dependencies = [
  "bitflags 2.6.0",
  "boa_interner",
  "boa_macros",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "num-bigint",
  "rustc-hash 2.0.0",
 ]
@@ -1350,11 +1361,11 @@ dependencies = [
  "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap",
+ "dashmap 5.5.3",
  "fast-float",
  "hashbrown 0.14.5",
  "icu_normalizer",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "intrusive-collections",
  "itertools 0.13.0",
  "num-bigint",
@@ -1400,7 +1411,7 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "once_cell",
  "phf",
  "rustc-hash 2.0.0",
@@ -1415,7 +1426,7 @@ checksum = "25e0097fa69cde4c95f9869654004340fbbe2bcf3ce9189ba2a31a65ac40e0a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "synstructure",
 ]
 
@@ -1498,13 +1509,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata 0.1.10",
+ "regex-automata 0.4.7",
+ "serde",
 ]
 
 [[package]]
@@ -1521,9 +1532,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1536,7 +1547,7 @@ checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1547,9 +1558,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -1617,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1693,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1703,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1715,27 +1726,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "combine"
@@ -1961,7 +1972,7 @@ dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
@@ -2080,7 +2091,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2104,7 +2115,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2115,7 +2126,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2125,6 +2136,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -2212,7 +2237,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2225,7 +2250,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2363,7 +2388,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2374,9 +2399,9 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2495,18 +2520,18 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2678,9 +2703,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2780,7 +2805,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2888,15 +2913,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 0.2.12",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2954,13 +2979,19 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.2.6",
+ "http",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbrown"
@@ -3098,17 +3129,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -3125,7 +3145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -3136,7 +3156,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -3191,7 +3211,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -3209,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "log",
@@ -3237,14 +3257,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -3393,7 +3413,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3514,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3544,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bafc2f5dbdad79a6d925649758d5472647b416028099f0b829d1b67fdd47d3"
+checksum = "d2f4e4a06d42fab3e85ab1b419ad32b09eab58b901d40c57935ff92db3287a13"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -3596,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3655,9 +3675,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -3673,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+checksum = "0a1d83ae9ed70d8e3440db663e343a82f93913104744cd543bbcdd1dbc0e35d3"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3691,15 +3711,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+checksum = "5be764c8b96cdcd2974655560a1c6542a366440d47c88114894cc20c24317815"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.1.0",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -3716,24 +3736,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+checksum = "83b772fb8aa2b511eeed75f7e19d8e5fa57be7e8202249470bf26210727399c7"
 dependencies = [
- "anyhow",
  "async-trait",
- "beef",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3745,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d90064e04fb9d7282b1c71044ea94d0bbc6eff5621c66f1a0bce9e9de7cf3ac"
+checksum = "4d5f8f6ddb09312a9592ec9e21a3ccd6f61e51730d9d56321351eff971b0fe55"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3770,26 +3788,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
+checksum = "295d9b81496d1bef5bd34066d83c984388b6acb97620f468817bf46f67a1e9ab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+checksum = "85bf179199ad809157ceaab653f71cdb67f55d9e0093a6907c5765414a6b3bbb"
 dependencies = [
- "anyhow",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3811,12 +3828,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
+checksum = "98deeee954567f75632fa40666ac93a66d4f9f4ed4ca15bd6b7ed0720b53e761"
 dependencies = [
- "beef",
- "http 1.1.0",
+ "http",
  "serde",
  "serde_json",
  "thiserror",
@@ -3824,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
+checksum = "4c8a01468705cf6d326b8ba9c035e71abf5cc5e10948ba46e8af151386878398"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3835,11 +3851,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+checksum = "385cf0a6103a9f64987cdf0f7c9d0b08e1d7183dd952820beffb3676e7df7787"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3886,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -3947,9 +3963,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -4203,9 +4219,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4296,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -4328,7 +4344,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -4394,6 +4410,18 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4614,23 +4642,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4649,6 +4677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "const-hex",
  "proptest",
  "serde",
@@ -4657,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -4676,11 +4705,11 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d10e10cbbdb3931fed5109bbd570c0a6cf0ce08db1f93401cfb5cefc51998d1"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "serde",
 ]
 
@@ -4692,8 +4721,8 @@ checksum = "9978c3d449abb03526d378988ae6d51b049ef36205cc97bf284574df9f578021"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.2.0",
- "alloy-serde 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
+ "alloy-serde 0.2.1",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -4719,9 +4748,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "num-traits",
 ]
@@ -4878,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
 ]
 
 [[package]]
@@ -4934,7 +4963,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4963,7 +4992,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4995,6 +5024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plain_hasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5014,9 +5052,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -5026,9 +5064,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5037,7 +5078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5179,7 +5220,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5209,7 +5250,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
  "tempfile",
 ]
 
@@ -5223,7 +5264,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5267,16 +5308,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -5284,14 +5326,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls",
  "slab",
  "thiserror",
@@ -5301,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -5504,9 +5546,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5584,7 +5626,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5629,8 +5671,8 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5673,6 +5715,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-node-optimism",
  "reth-optimism-cli",
  "reth-optimism-primitives",
@@ -5698,6 +5741,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5710,8 +5754,8 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -5737,8 +5781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -5760,8 +5804,8 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures",
  "itertools 0.13.0",
@@ -5794,8 +5838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -5817,6 +5861,7 @@ dependencies = [
  "reth-stages-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "reth-trie-parallel",
  "tokio",
  "tracing",
@@ -5824,8 +5869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -5835,12 +5880,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-chain-state"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
+dependencies = [
+ "auto_impl",
+ "derive_more",
+ "metrics",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-trie",
+ "revm",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "reth-chainspec"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-chains",
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -5857,8 +5926,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "clap",
  "eyre",
@@ -5868,8 +5937,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "ahash",
  "backon",
@@ -5882,7 +5951,6 @@ dependencies = [
  "futures",
  "human_bytes",
  "itertools 0.13.0",
- "metrics-process",
  "ratatui",
  "reth-beacon-consensus",
  "reth-chainspec",
@@ -5894,14 +5962,18 @@ dependencies = [
  "reth-db-api",
  "reth-db-common",
  "reth-downloaders",
+ "reth-ecies",
+ "reth-eth-wire",
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
  "reth-network",
  "reth-network-p2p",
+ "reth-network-peers",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-primitives",
  "reth-provider",
  "reth-prune",
@@ -5909,6 +5981,8 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-trie",
+ "reth-trie-db",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
@@ -5918,8 +5992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5928,10 +6002,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "eyre",
  "libc",
@@ -5943,11 +6017,11 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -5959,19 +6033,19 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "reth-config"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "confy",
  "humantime-serde",
@@ -5983,8 +6057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "auto_impl",
  "reth-primitives",
@@ -5993,8 +6067,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6003,11 +6077,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-provider",
  "auto_impl",
  "eyre",
@@ -6026,8 +6100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "bytes",
  "derive_more",
@@ -6057,8 +6131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -6079,8 +6153,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -6096,6 +6170,7 @@ dependencies = [
  "reth-provider",
  "reth-stages-types",
  "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "thiserror",
@@ -6104,8 +6179,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6128,8 +6203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6154,8 +6229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6176,8 +6251,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -6203,8 +6278,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "aes 0.8.4",
  "alloy-primitives",
@@ -6234,8 +6309,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -6244,23 +6319,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "aquamarine",
  "futures",
  "metrics",
- "parking_lot 0.12.3",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
  "reth-blockchain-tree-api",
- "reth-chainspec",
+ "reth-chain-state",
  "reth-consensus",
  "reth-db",
  "reth-db-api",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-consensus",
  "reth-evm",
  "reth-metrics",
  "reth-network-p2p",
@@ -6270,25 +6342,20 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-prune",
- "reth-prune-types",
  "reth-revm",
  "reth-rpc-types",
  "reth-stages-api",
- "reth-stages-types",
- "reth-static-file",
  "reth-tasks",
- "reth-tokio-util",
  "reth-trie",
- "revm",
+ "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-engine-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "eyre",
  "futures",
@@ -6306,8 +6373,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -6319,8 +6386,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -6344,8 +6411,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -6360,8 +6427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6372,8 +6439,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures",
  "pin-project",
@@ -6382,18 +6449,22 @@ dependencies = [
  "reth-db-api",
  "reth-engine-tree",
  "reth-ethereum-engine-primitives",
+ "reth-evm-ethereum",
  "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-validator",
+ "reth-provider",
+ "reth-prune",
  "reth-stages-api",
  "reth-tasks",
  "thiserror",
- "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -6410,8 +6481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6430,8 +6501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -6449,8 +6520,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6459,10 +6530,10 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "auto_impl",
  "futures-util",
  "parking_lot 0.12.3",
@@ -6478,10 +6549,10 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-sol-types",
  "reth-chainspec",
  "reth-ethereum-consensus",
@@ -6496,11 +6567,10 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-optimism"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
- "reth-consensus-common",
  "reth-ethereum-forks",
  "reth-evm",
  "reth-execution-errors",
@@ -6517,11 +6587,13 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
+ "alloy-rlp",
+ "nybbles",
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
@@ -6531,8 +6603,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-execution-errors",
@@ -6544,8 +6616,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "eyre",
  "futures",
@@ -6554,7 +6626,6 @@ dependencies = [
  "reth-evm",
  "reth-exex-types",
  "reth-metrics",
- "reth-network",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -6572,8 +6643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "eyre",
  "futures-util",
@@ -6603,8 +6674,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "reth-provider",
@@ -6613,8 +6684,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "serde",
  "serde_json",
@@ -6623,8 +6694,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6644,14 +6715,14 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
- "dashmap",
+ "dashmap 6.0.1",
  "derive_more",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "parking_lot 0.12.3",
  "reth-mdbx-sys",
  "thiserror",
@@ -6660,8 +6731,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "bindgen",
  "cc",
@@ -6669,8 +6740,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures",
  "metrics",
@@ -6681,28 +6752,28 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics-derive"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6713,8 +6784,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6763,32 +6834,40 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "auto_impl",
+ "derive_more",
  "enr",
- "reth-eth-wire",
+ "futures",
+ "reth-eth-wire-types",
+ "reth-ethereum-forks",
+ "reth-network-p2p",
  "reth-network-peers",
+ "reth-network-types",
+ "reth-tokio-util",
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "auto_impl",
  "futures",
  "reth-consensus",
  "reth-eth-wire-types",
- "reth-network-api",
  "reth-network-peers",
  "reth-primitives",
  "reth-storage-errors",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",
@@ -6796,8 +6875,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6811,12 +6890,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "humantime-serde",
+ "reth-ethereum-forks",
  "reth-net-banlist",
- "reth-network-api",
+ "reth-network-p2p",
  "reth-network-peers",
  "serde",
  "serde_json",
@@ -6825,8 +6905,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6845,13 +6925,13 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
  "reth-evm",
- "reth-network",
+ "reth-network-api",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
@@ -6861,11 +6941,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "aquamarine",
- "backon",
  "confy",
  "eyre",
  "fdlimit",
@@ -6887,10 +6966,12 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-network",
+ "reth-network-api",
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
@@ -6914,8 +6995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -6925,15 +7006,7 @@ dependencies = [
  "dirs-next",
  "eyre",
  "futures",
- "http 1.1.0",
  "humantime",
- "jsonrpsee",
- "metrics",
- "metrics-exporter-prometheus",
- "metrics-process",
- "metrics-util",
- "once_cell",
- "procfs",
  "rand 0.8.5",
  "reth-chainspec",
  "reth-cli-util",
@@ -6944,7 +7017,6 @@ dependencies = [
  "reth-discv4",
  "reth-discv5",
  "reth-fs-util",
- "reth-metrics",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
@@ -6960,30 +7032,28 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-errors",
- "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
  "secp256k1",
  "serde_json",
  "shellexpand",
- "tikv-jemalloc-ctl",
- "tokio",
- "tower",
  "tracing",
  "vergen",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "eyre",
  "futures",
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
+ "reth-blockchain-tree",
  "reth-consensus",
+ "reth-engine-tree",
  "reth-ethereum-engine",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
@@ -7009,8 +7079,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -7031,9 +7101,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-node-metrics"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
+dependencies = [
+ "eyre",
+ "http",
+ "jsonrpsee",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "metrics-util",
+ "once_cell",
+ "procfs",
+ "reth-db-api",
+ "reth-metrics",
+ "reth-provider",
+ "reth-tasks",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tower",
+ "tracing",
+ "vergen",
+]
+
+[[package]]
 name = "reth-node-optimism"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "async-trait",
  "clap",
@@ -7077,8 +7172,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -7117,8 +7212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -7129,8 +7224,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
@@ -7154,21 +7249,22 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
+ "derive_more",
  "jsonrpsee",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec",
- "reth-errors",
  "reth-evm",
  "reth-evm-optimism",
+ "reth-network-api",
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
@@ -7187,8 +7283,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures-util",
  "metrics",
@@ -7208,8 +7304,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-errors",
@@ -7223,8 +7319,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -7234,10 +7330,10 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -7246,6 +7342,7 @@ dependencies = [
  "bytes",
  "c-kzg",
  "derive_more",
+ "k256",
  "modular-bitfield",
  "once_cell",
  "proptest",
@@ -7266,15 +7363,15 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-eips 0.2.0",
+ "alloy-consensus 0.2.1",
+ "alloy-eips 0.2.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 0.2.0",
+ "alloy-rpc-types-eth 0.2.1",
  "arbitrary",
  "byteorder",
  "bytes",
@@ -7290,20 +7387,19 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap",
- "derive_more",
+ "dashmap 6.0.1",
  "itertools 0.13.0",
  "metrics",
  "parking_lot 0.12.3",
- "pin-project",
  "rayon",
  "reth-blockchain-tree-api",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-codecs",
  "reth-db",
@@ -7321,17 +7417,17 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "revm",
  "strum",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -7356,8 +7452,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7370,10 +7466,10 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "reth-chainspec",
  "reth-consensus-common",
  "reth-execution-errors",
@@ -7382,13 +7478,12 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "revm",
- "tracing",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -7397,7 +7492,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "futures",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "jsonrpsee",
@@ -7411,6 +7506,7 @@ dependencies = [
  "reth-evm",
  "reth-network-api",
  "reth-network-peers",
+ "reth-network-types",
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
@@ -7424,6 +7520,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tasks",
  "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7440,8 +7537,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "jsonrpsee",
  "reth-engine-primitives",
@@ -7453,10 +7550,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee",
  "metrics",
  "pin-project",
@@ -7484,8 +7581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
@@ -7512,8 +7609,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-dyn-abi",
  "async-trait",
@@ -7521,11 +7618,13 @@ dependencies = [
  "dyn-clone",
  "futures",
  "jsonrpsee",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
  "reth-execution-types",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
@@ -7544,8 +7643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-sol-types",
  "derive_more",
@@ -7581,11 +7680,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rpc-types-engine",
- "http 1.1.0",
+ "http",
  "jsonrpsee-http-client",
  "pin-project",
  "tower",
@@ -7594,8 +7693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
@@ -7610,8 +7709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7622,14 +7721,14 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 0.2.0",
+ "alloy-serde 0.2.1",
  "jsonrpsee-types",
 ]
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -7640,8 +7739,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -7666,6 +7765,7 @@ dependencies = [
  "reth-stages-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",
@@ -7673,8 +7773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -7700,8 +7800,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7713,8 +7813,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -7733,8 +7833,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7745,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -7762,9 +7862,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
+ "alloy-rlp",
  "reth-fs-util",
  "reth-primitives",
  "thiserror-no-std",
@@ -7772,8 +7873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7790,8 +7891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-genesis",
  "rand 0.8.5",
@@ -7801,8 +7902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7811,8 +7912,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "clap",
  "eyre",
@@ -7826,8 +7927,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7859,8 +7960,54 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
+dependencies = [
+ "alloy-rlp",
+ "auto_impl",
+ "derive_more",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "revm",
+ "serde",
+ "tracing",
+ "triehash",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
+dependencies = [
+ "alloy-consensus 0.2.1",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "arbitrary",
+ "bytes",
+ "derive_more",
+ "hash-db",
+ "itertools 0.13.0",
+ "nybbles",
+ "plain_hasher",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "reth-trie-db"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7874,36 +8021,17 @@ dependencies = [
  "reth-metrics",
  "reth-primitives",
  "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie",
  "reth-trie-common",
  "revm",
- "serde",
  "tracing",
 ]
 
 [[package]]
-name = "reth-trie-common"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
-dependencies = [
- "alloy-consensus 0.2.0",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "bytes",
- "derive_more",
- "itertools 0.13.0",
- "nybbles",
- "reth-codecs",
- "reth-primitives-traits",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
 name = "reth-trie-parallel"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth#390f30aadebcdd509e72cc04327c3b854de076a6"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth#365012b9ca3a13caef1263a9a46d1fc0fde262b6"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -7918,6 +8046,7 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",
@@ -7940,9 +8069,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d485a7ccfbbcaf2d0c08c3d866dae279c6f71d7357862cbea637f23f27b7b695"
+checksum = "54a785dafff303a335980e317669c4e9800cdd5dd2830c6880c3247022761e88"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7992,7 +8121,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
 dependencies = [
- "alloy-eips 0.2.0",
+ "alloy-eips 0.2.1",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",
@@ -8091,7 +8220,7 @@ dependencies = [
 name = "rollup"
 version = "0.0.0"
 dependencies = [
- "alloy-consensus 0.2.0",
+ "alloy-consensus 0.2.1",
  "alloy-rlp",
  "alloy-sol-types",
  "eyre",
@@ -8223,9 +8352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
  "once_cell",
@@ -8251,9 +8380,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -8261,15 +8390,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
+checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -8288,15 +8417,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8502,26 +8631,27 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -8548,7 +8678,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8565,7 +8695,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8574,7 +8704,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
  "ryu",
  "serde",
@@ -8628,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8672,12 +8802,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -8702,9 +8832,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -8759,6 +8889,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
+ "arbitrary",
  "serde",
 ]
 
@@ -8797,7 +8928,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -8833,7 +8964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8873,7 +9004,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8918,9 +9049,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8936,7 +9067,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8959,7 +9090,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -8984,12 +9115,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -9017,7 +9149,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -9160,32 +9292,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.1",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -9244,21 +9375,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -9269,22 +9400,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.16"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -9299,7 +9430,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -9327,7 +9458,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -9363,7 +9494,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -9426,7 +9557,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -9473,9 +9604,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
  "time",
  "tracing",
@@ -9512,6 +9643,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
 ]
 
 [[package]]
@@ -9575,7 +9716,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9782,9 +9923,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -9853,7 +9994,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -9887,7 +10028,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9951,11 +10092,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10013,7 +10154,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10024,7 +10165,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10050,6 +10191,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -10186,9 +10336,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -10282,7 +10432,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "synstructure",
 ]
 
@@ -10292,6 +10442,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -10303,7 +10454,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10323,7 +10474,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "synstructure",
 ]
 
@@ -10344,7 +10495,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10366,7 +10517,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10380,18 +10531,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", version = "1
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
 reth-revm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
 
 # alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,20 +19,19 @@ publish = false
 
 [workspace.dependencies]
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", features = ["serde"] }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth" }
+reth = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", features = ["serde"], version = "1.0.3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
 
 # alloy
 alloy-sol-types = { version = "0.7", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,20 +19,20 @@ publish = false
 
 [workspace.dependencies]
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", features = ["serde"], version = "1.0.3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", version = "1.0.3" }
+reth = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", features = ["serde"], version = "1.0.4" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", version = "1.0.4" }
 
 # alloy
 alloy-sol-types = { version = "0.7", features = ["json"] }

--- a/backfill/Cargo.toml
+++ b/backfill/Cargo.toml
@@ -22,7 +22,7 @@ tokio.workspace = true
 
 # rpc
 async-trait = "0.1"
-jsonrpsee = { version = "0.23", features = ["server", "macros"] }
+jsonrpsee = { version = "0.24.2", features = ["server", "macros"] }
 
 # cli
 clap = "4"

--- a/backfill/Cargo.toml
+++ b/backfill/Cargo.toml
@@ -22,7 +22,7 @@ tokio.workspace = true
 
 # rpc
 async-trait = "0.1"
-jsonrpsee = { version = "0.24.2", features = ["server", "macros"] }
+jsonrpsee = { version = "0.24", features = ["server", "macros"] }
 
 # cli
 clap = "4"

--- a/backfill/src/main.rs
+++ b/backfill/src/main.rs
@@ -6,12 +6,8 @@ use clap::{Args, Parser};
 use eyre::OptionExt;
 use futures::{FutureExt, TryStreamExt};
 use jsonrpsee::tracing::instrument;
-use reth::{
-    primitives::{BlockId, BlockNumber, BlockNumberOrTag, Requests},
-    providers::{BlockIdReader, BlockReader, HeaderProvider, StateProviderFactory},
-};
-use reth_evm::execute::BlockExecutorProvider;
-use reth_execution_types::{Chain, ExecutionOutcome};
+use reth::primitives::BlockNumber;
+use reth_execution_types::Chain;
 use reth_exex::{BackfillJob, BackfillJobFactory, ExExContext, ExExEvent, ExExNotification};
 use reth_node_api::FullNodeComponents;
 use reth_node_ethereum::EthereumNode;
@@ -189,7 +185,13 @@ impl<Node: FullNodeComponents> BackfillExEx<Node> {
         backfill_tx: mpsc::UnboundedSender<BackfillMessage>,
         cancel_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
-        let backfill = backfill_with_job(job);
+        let backfill = job
+            // Convert the backfill job into a parallel stream
+            .into_stream()
+            // Convert the block execution error into `eyre` error type
+            .map_err(Into::into)
+            // Process each block, returning early if an error occurs
+            .try_for_each(|chain| async move { Self::process_committed_chain(&chain).await });
 
         tokio::select! {
             result = backfill => {


### PR DESCRIPTION
This PR pins the version of Reth used across all examples. 
Notably, the latest version broke the backfill example. This issue is also breaking CI in #12.

