### PR TITLE
Fixed JumpTable encoding in exex-remote

### DIFF
--- a/remote/proto/exex.proto
+++ b/remote/proto/exex.proto
@@ -236,7 +236,8 @@ message Bytecode {
 message LegacyAnalyzedBytecode {
   bytes bytecode = 1;
   uint64 original_len = 2;
-  repeated uint32 jump_table = 3;
+  bytes jump_table = 3;
+  uint64 jump_table_len = 4;
 }
 
 message Eip7702Bytecode {

--- a/remote/src/codec.rs
+++ b/remote/src/codec.rs
@@ -351,13 +351,8 @@ impl TryFrom<&reth::revm::bytecode::Bytecode> for proto::Bytecode {
                 proto::bytecode::Bytecode::LegacyAnalyzed(proto::LegacyAnalyzedBytecode {
                     bytecode: legacy_analyzed.bytecode().to_vec(),
                     original_len: legacy_analyzed.original_len() as u64,
-                    jump_table: legacy_analyzed
-                        .jump_table()
-                        .as_slice()
-                        .iter()
-                        .copied()
-                        .map(|x| x as u32)
-                        .collect(),
+                    jump_table: legacy_analyzed.jump_table().as_slice().iter().copied().collect(),
+                    jump_table_len: legacy_analyzed.jump_table().len() as u64,
                 })
             }
             reth::revm::state::Bytecode::Eip7702(eip7702) => {
@@ -870,10 +865,10 @@ impl TryFrom<&proto::Bytecode> for reth::revm::state::Bytecode {
                             legacy_analyzed
                                 .jump_table
                                 .iter()
-                                .map(|dest| *dest as u8)
+                                .copied()
                                 .collect::<Vec<_>>()
                                 .as_slice(),
-                            legacy_analyzed.jump_table.len(),
+                            legacy_analyzed.jump_table_len as usize,
                         ),
                     ),
                 )


### PR DESCRIPTION
Fix for this issue: https://github.com/paradigmxyz/reth-exex-examples/issues/48

Previously each bit of the jump table was encoded as a u32, therefore we didn't need to encode the length. 
Since latest commit, the jump table is encoded as a collection of bytes cast as u32's and it broke the encoding.

With this commit we encode both the jump table (as a collection of bytes) and the length to accurately decode the proto type into the revm type. 